### PR TITLE
Fix: Correct module references and exports

### DIFF
--- a/src/cognitive_integration.ts
+++ b/src/cognitive_integration.ts
@@ -18,7 +18,7 @@
  * 在记忆、思考、自省与共情的星辰之间流动。
  */
 
-import { kv } from "./main.ts"; // 确保 main.ts 导出 kv
+import { kvHolder } from "./main.ts"; // 确保 main.ts 导出 kvHolder
 import { config } from "./config.ts";
 import { llm } from "./llm.ts";
 import { embeddings } from "./embeddings.ts";
@@ -583,7 +583,7 @@ export class CognitiveIntegrationManager {
     if (!this.currentState) return;
 
     try {
-      await kv.set(["cognitive_state", "current"], this.currentState);
+      await kvHolder.instance.set(["cognitive_state", "current"], this.currentState);
     } catch (error) {
       console.error(`❌ 持久化认知状态时出错: ${error}`);
     }

--- a/src/cognitive_utils.ts
+++ b/src/cognitive_utils.ts
@@ -3,7 +3,7 @@
 import { llm } from "./llm.ts";
 import type { EmotionDimension } from "./qdrant_client.ts";
 import { config } from "./config.ts";
-import { LLMError, ModuleError } from "../errors.ts";
+import { LLMError, ModuleError, BaseError } from "./errors.ts";
 export async function analyzeMessageSentiment(text: string): Promise<{
   valence: number;
   arousal: number;
@@ -222,9 +222,6 @@ export async function detectImportantMessage(messageText: string): Promise<
       prompt: prompt.substring(0, 200) + "...",
     });
     // Fallback return is removed.
-      emotionDimensions: { "neutral": 1.0 },
-      dominant_emotion: "neutral",
-    };
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@
 /**
  * 配置模块 - 管理应用程序的所有配置项
  */
-import { load } from "https://deno.land/std@0.220.1/dotenv/mod.ts";
+import { load } from "https://deno.land/std@0.224.0/dotenv/mod.ts";
 
 // --- 加载环境变量 ---
 let envVars: Record<string, string> = {};

--- a/src/stm_manager.ts
+++ b/src/stm_manager.ts
@@ -2,7 +2,7 @@
 
 import { kvHolder } from "./main.ts";
 import type { ChatMessageInput } from "./memory_processor.ts";
-import { KVStoreError, BaseError } from "../errors.ts"; // Import custom errors
+import { KVStoreError, BaseError } from "./errors.ts"; // Import custom errors
 import { config } from "./config.ts"; // 1. Import config
 
 export const STM_MAX_MESSAGES = 15; // 短期记忆最大消息数

--- a/src/stm_manager_test.ts
+++ b/src/stm_manager_test.ts
@@ -23,7 +23,7 @@ import {
 import { config } from "./config.ts";
 import { kvHolder } from "./main.ts"; // Assuming main.ts exports kvHolder
 import type { ChatMessageInput } from "./memory_processor.ts";
-import { BaseError, KVStoreError } from "../errors.ts";
+import { BaseError, KVStoreError } from "./errors.ts";
 
 
 // Helper function to create mock messages


### PR DESCRIPTION
This commit addresses several issues related to module imports, exports, and Deno KV instance usage across the `src/` directory.

Key changes include:
- Corrected Deno KV instance usage in `src/memory_network.ts`, `src/cognitive_integration.ts`, `src/social_cognition.ts`, and `src/thought_streams.ts` to use `kvHolder.instance` instead of a direct `kv` import.
- Fixed incorrect import paths for `errors.ts` in `src/cognitive_utils.ts`, `src/stm_manager.ts`, `src/memory_network.ts`, and `src/stm_manager_test.ts` from `../errors.ts` to `./errors.ts`.
- Unified the Deno Standard Library version for `dotenv` in `src/config.ts` to `std@0.224.0`.
- Removed a redundant import of `config.ts` in `src/memory_network.ts`.

These changes ensure better code consistency, correct runtime behavior for KV operations, and proper error module referencing.